### PR TITLE
Check validity of protocol and timeout

### DIFF
--- a/.idea/dictionaries/jco59.xml
+++ b/.idea/dictionaries/jco59.xml
@@ -1,0 +1,7 @@
+<component name="ProjectDictionaryState">
+  <dictionary name="jco59">
+    <words>
+      <w>syft</w>
+    </words>
+  </dictionary>
+</component>

--- a/demo-app/src/main/java/org/openmined/syft/demo/StandaloneDemo.kt
+++ b/demo-app/src/main/java/org/openmined/syft/demo/StandaloneDemo.kt
@@ -11,7 +11,7 @@ fun main() {
     val syft = Syft(
         "myWorker",
         2000,
-        "ws://echo.websocket.org",
+        "wss://echo.websocket.org",
         object : ProcessSchedulers {
             override val computeThreadScheduler: Scheduler
                 get() = Schedulers.computation()
@@ -20,5 +20,5 @@ fun main() {
         }
     )
 
-    syft?.start() ?: println("Something went wrong can couldn't start Syft")
+    syft?.start() ?: println("Something went wrong. Couldn't start Syft")
 }

--- a/demo-app/src/main/java/org/openmined/syft/demo/StandaloneDemo.kt
+++ b/demo-app/src/main/java/org/openmined/syft/demo/StandaloneDemo.kt
@@ -4,14 +4,20 @@ import io.reactivex.Scheduler
 import io.reactivex.schedulers.Schedulers
 import kotlinx.serialization.ImplicitReflectionSerializer
 import org.openmined.syft.Syft
+import org.openmined.syft.domain.Protocol
+import org.openmined.syft.network.SignallingClient
 import org.openmined.syft.threading.ProcessSchedulers
 
+@ExperimentalUnsignedTypes
 @ImplicitReflectionSerializer
 fun main() {
     val syft = Syft(
-        "myWorker",
-        2000,
-        "wss://echo.websocket.org",
+        SignallingClient(
+            "myWorker",
+            Protocol.WSS,
+            "echo.websocket.org",
+            2000u
+        ),
         object : ProcessSchedulers {
             override val computeThreadScheduler: Scheduler
                 get() = Schedulers.computation()
@@ -19,6 +25,5 @@ fun main() {
                 get() = Schedulers.single()
         }
     )
-
-    syft?.start() ?: println("Something went wrong. Couldn't start Syft")
+    syft.start()
 }

--- a/demo-app/src/main/java/org/openmined/syft/demo/StandaloneDemo.kt
+++ b/demo-app/src/main/java/org/openmined/syft/demo/StandaloneDemo.kt
@@ -20,5 +20,5 @@ fun main() {
         }
     )
 
-    syft.start()
+    syft?.start() ?: println("Something went wrong can couldn't start Syft")
 }

--- a/syftlib/build.gradle
+++ b/syftlib/build.gradle
@@ -60,4 +60,5 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.6.0'
     testImplementation "org.mockito:mockito-core:3.2.4"
+    testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
 }

--- a/syftlib/src/main/java/org/openmined/syft/Syft.kt
+++ b/syftlib/src/main/java/org/openmined/syft/Syft.kt
@@ -24,24 +24,24 @@ class Syft private constructor(
             url: String,
             schedulers: ProcessSchedulers
         ): Syft? =
-            Syft(workerId, keepAliveTimeout, url, schedulers).takeIf { isValid(it) }
+                Syft(workerId, keepAliveTimeout, url, schedulers).takeIf { isValid(it) }
 
         private fun isValid(syft: Syft): Boolean {
             return checkProtocol(syft.url) &&
-                    checkKeepAliveTimeout(syft.keepAliveTimeout)
+                   checkKeepAliveTimeout(syft.keepAliveTimeout)
         }
 
         private fun checkProtocol(url: String) =
-            if (!url.startsWith("wss", true)) {
-                println("Protocol must be wss")
-                false
-            } else true
+                if (!url.startsWith("wss", true)) {
+                    println("Protocol must be wss")
+                    false
+                } else true
 
         private fun checkKeepAliveTimeout(timeout: Int) =
-            if (timeout < 0) {
-                println("keep alive timeout must be equals or greater than 0")
-                false
-            } else true
+                if (timeout < 0) {
+                    println("keep alive timeout must be equals or greater than 0")
+                    false
+                } else true
     }
 
     @ImplicitReflectionSerializer
@@ -53,21 +53,21 @@ class Syft private constructor(
         )
 
         val disposable = signallingClient.start()
-            .map {
-                when (it) {
-                    is NetworkMessage.SocketOpen -> {
-                        println("Socket open")
-                        send("And now that we are opened, I send a message")
+                .map {
+                    when (it) {
+                        is NetworkMessage.SocketOpen -> {
+                            println("Socket open")
+                            send("And now that we are opened, I send a message")
+                        }
+                        is NetworkMessage.SocketClosed -> println("Socket was closed successfully")
+                        is NetworkMessage.SocketError -> println(it.throwable.message)
+                        is NetworkMessage.MessageReceived -> println(it)
+                        is NetworkMessage.MessageSent -> println("Message sent successfully")
                     }
-                    is NetworkMessage.SocketClosed -> println("Socket was closed successfully")
-                    is NetworkMessage.SocketError -> println(it.throwable.message)
-                    is NetworkMessage.MessageReceived -> println(it)
-                    is NetworkMessage.MessageSent -> println("Message sent successfully")
                 }
-            }
-            .subscribeOn(schedulers.computeThreadScheduler)
-            .observeOn(schedulers.calleeThreadScheduler)
-            .subscribe()
+                .subscribeOn(schedulers.computeThreadScheduler)
+                .observeOn(schedulers.calleeThreadScheduler)
+                .subscribe()
 
         compositeDisposable.add(disposable)
     }

--- a/syftlib/src/main/java/org/openmined/syft/Syft.kt
+++ b/syftlib/src/main/java/org/openmined/syft/Syft.kt
@@ -8,19 +8,44 @@ import org.openmined.syft.network.NetworkMessage
 import org.openmined.syft.network.SignallingClient
 import org.openmined.syft.threading.ProcessSchedulers
 
-class Syft(
+class Syft private constructor(
     private val workerId: String,
     private val keepAliveTimeout: Int = 20000,
     private val url: String,
     private val schedulers: ProcessSchedulers
 ) {
-
     private lateinit var signallingClient: SignallingClient
     private val compositeDisposable = CompositeDisposable()
 
+    companion object {
+        operator fun invoke(
+            workerId: String,
+            keepAliveTimeout: Int = 20000,
+            url: String,
+            schedulers: ProcessSchedulers
+        ): Syft? =
+            Syft(workerId, keepAliveTimeout, url, schedulers).takeIf { isValid(it) }
+
+        private fun isValid(syft: Syft): Boolean {
+            return checkProtocol(syft.url) &&
+                    checkKeepAliveTimeout(syft.keepAliveTimeout)
+        }
+
+        private fun checkProtocol(url: String) =
+            if (!url.startsWith("wss", true)) {
+                println("Protocol must be wss")
+                false
+            } else true
+
+        private fun checkKeepAliveTimeout(timeout: Int) =
+            if (timeout < 0) {
+                println("keep alive timeout must be equals or greater than 0")
+                false
+            } else true
+    }
+
     @ImplicitReflectionSerializer
     fun start() {
-        // Create signalling client and execute it in background thread
         signallingClient = SignallingClient(
             workerId,
             url,
@@ -28,35 +53,32 @@ class Syft(
         )
 
         val disposable = signallingClient.start()
-                .map {
-                    // TODO Please excuse this terrible piece of code
-                    when (it) {
-                        is NetworkMessage.SocketOpen -> {
-                            println("Socket open")
-                            send("And now that we are opened, I send a message")
-                        }
-                        is NetworkMessage.SocketClosed -> println("Socket was closed successfully")
-                        is NetworkMessage.SocketError -> println(it.throwable.message)
-                        is NetworkMessage.MessageReceived -> println(it)
-                        is NetworkMessage.MessageSent -> println("Message sent successfully")
+            .map {
+                when (it) {
+                    is NetworkMessage.SocketOpen -> {
+                        println("Socket open")
+                        send("And now that we are opened, I send a message")
                     }
+                    is NetworkMessage.SocketClosed -> println("Socket was closed successfully")
+                    is NetworkMessage.SocketError -> println(it.throwable.message)
+                    is NetworkMessage.MessageReceived -> println(it)
+                    is NetworkMessage.MessageSent -> println("Message sent successfully")
                 }
-                .subscribeOn(schedulers.computeThreadScheduler)
-                .observeOn(schedulers.calleeThreadScheduler)
-                .subscribe()
+            }
+            .subscribeOn(schedulers.computeThreadScheduler)
+            .observeOn(schedulers.calleeThreadScheduler)
+            .subscribe()
 
         compositeDisposable.add(disposable)
     }
 
     @ImplicitReflectionSerializer
-    fun send(message: String) {
-        signallingClient.send(
-            "Personal", JsonObject(
-                mapOf(
-                    "data" to JsonPrimitive(message),
-                    "workerId" to JsonPrimitive("1234")
-                )
+    fun send(message: String) = signallingClient.send(
+        "Personal", JsonObject(
+            mapOf(
+                "data" to JsonPrimitive(message),
+                "workerId" to JsonPrimitive("1234")
             )
         )
-    }
+    )
 }

--- a/syftlib/src/main/java/org/openmined/syft/domain/Protocol.kt
+++ b/syftlib/src/main/java/org/openmined/syft/domain/Protocol.kt
@@ -1,0 +1,9 @@
+package org.openmined.syft.domain
+
+sealed class Protocol {
+    object WSS : Protocol() {
+        override fun toString(): String {
+            return "wss"
+        }
+    }
+}

--- a/syftlib/src/main/java/org/openmined/syft/network/SignallingClient.kt
+++ b/syftlib/src/main/java/org/openmined/syft/network/SignallingClient.kt
@@ -10,14 +10,17 @@ import okhttp3.Request
 import okhttp3.Response
 import okhttp3.WebSocket
 import okhttp3.WebSocketListener
+import org.openmined.syft.domain.Protocol
 import java.util.concurrent.TimeUnit
 
 private const val SOCKET_CLOSE_CLIENT = 1000
 
-internal class SignallingClient(
+@ExperimentalUnsignedTypes
+class SignallingClient(
     private val workerId: String,
-    private val url: String,
-    private val keepAliveTimeout: Int = 20000
+    private val protocol: Protocol,
+    private val address: String,
+    private val keepAliveTimeout: UInt = 20000u
 ) {
     private lateinit var request: Request
     private lateinit var client: OkHttpClient
@@ -32,7 +35,7 @@ internal class SignallingClient(
                 .pingInterval(keepAliveTimeout.toLong(), TimeUnit.MILLISECONDS)
                 .build()
         request = Request.Builder()
-                .url(url)
+                .url("$protocol://$address")
                 .build()
         connect()
         return statusPublishProcessor.onBackpressureBuffer()

--- a/syftlib/src/test/java/org/openmined/syft/SyftTest.kt
+++ b/syftlib/src/test/java/org/openmined/syft/SyftTest.kt
@@ -8,6 +8,18 @@ import org.openmined.syft.threading.ProcessSchedulers
 internal class SyftTest {
 
     @Test
+    fun `Given params are all correct then constructor will return a valid Syft object`() {
+        val workerId = "workerId"
+        val keepAliveTimeout = 20000
+        val url = "wss://someAddress"
+        val schedulers = mock<ProcessSchedulers>()
+
+        val cut = Syft(workerId, keepAliveTimeout, url, schedulers)
+
+        assert(cut != null)
+    }
+
+    @Test
     fun `Given socket protocol is not wss then constructor will return a null object`() {
         val workerId = "workerId"
         val keepAliveTimeout = 20000

--- a/syftlib/src/test/java/org/openmined/syft/SyftTest.kt
+++ b/syftlib/src/test/java/org/openmined/syft/SyftTest.kt
@@ -1,0 +1,33 @@
+package org.openmined.syft
+
+import com.nhaarman.mockitokotlin2.mock
+import org.junit.jupiter.api.Test
+import org.openmined.syft.threading.ProcessSchedulers
+
+
+internal class SyftTest {
+
+    @Test
+    fun `Given socket protocol is not wss then constructor will return a null object`() {
+        val workerId = "workerId"
+        val keepAliveTimeout = 20000
+        val url = "ws://someAddress"
+        val schedulers = mock<ProcessSchedulers>()
+
+        val cut = Syft(workerId, keepAliveTimeout, url, schedulers)
+
+        assert(cut == null)
+    }
+
+    @Test
+    fun `Given keep alive protocol is negative then constructor will return a null object`() {
+        val workerId = "workerId"
+        val keepAliveTimeout = -10
+        val url = "wss://someAddress"
+        val schedulers = mock<ProcessSchedulers>()
+
+        val cut = Syft(workerId, keepAliveTimeout, url, schedulers)
+
+        assert(cut == null)
+    }
+}


### PR DESCRIPTION
Add validation for the params used to build a `Syft` object.
Initially this PR just prints the error in console.

If the object cannot be built, it will return a null value (this could be improved with `Option` or similar approaches).

