### PR TITLE
corrected badge position and ndk cache permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,9 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
     - name: Create ndk cache dir
-      run: sudo mkdir -p /usr/local/lib/android/sdk/ndk
+      run: |
+        sudo mkdir -p /usr/local/lib/android/sdk/ndk
+        sudo chown -R $USER /usr/local/lib/android/sdk/ndk
     - name: NDK Cache
       id: ndk-cache
       uses: actions/cache@v2

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ![KotlinSyft-logo](project_resources/pysyft_android.png)
-<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-5-orange.svg?style=flat-square)](#contributors-)
-<!-- ALL-CONTRIBUTORS-BADGE:END -->
 ![Tests](<https://img.shields.io/github/workflow/status/OpenMined/KotlinSyft/Testing Workflow?label=tests>)
 ![Coverage](https://img.shields.io/codecov/c/github/OpenMined/KotlinSyft/dev)
 ![build](https://github.com/OpenMined/KotlinSyft/workflows/Android%20CI/badge.svg)
 ![License](https://img.shields.io/github/license/OpenMined/KotlinSyft)
 ![OpenCollective](https://img.shields.io/opencollective/all/openmined)
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+[![All Contributors](https://img.shields.io/badge/all_contributors-5-orange.svg?style=flat-square)](#contributors-)
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 # KotlinSyft
 KotlinSyft makes it easy for you to **train and inference PySyft models on Android devices**. This allows you to utilize training data located directly on the device itself, bypassing the need to send a user's data to a central server. This is known as [federated learning](https://ai.googleblog.com/2017/04/federated-learning-collaborative.html).


### PR DESCRIPTION
# Pull Request

## Description
The github action still fails to create new directories within ndk folder. The PR seeks to allot the permissions.

Reordered all contributors badge 

## Type of Change
Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation (non-breaking change which adds documentation)
- [ ] Improvement (non-breaking change that improves the performance or reliability of existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
- Will get to see in CI tests, the step ndk install should not run in build action

## Checklist
- [x] I did follow the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md)
- [x] I did follow the [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have added tests for my changes

## Additional Context
None
