### PR TITLE
Implement exponential backoff

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -9,15 +9,6 @@
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value />
       </option>
-      <option name="PACKAGES_IMPORT_LAYOUT">
-        <value>
-          <package name="" alias="false" withSubpackages="true" />
-          <package name="java" alias="false" withSubpackages="true" />
-          <package name="javax" alias="false" withSubpackages="true" />
-          <package name="kotlin" alias="false" withSubpackages="true" />
-          <package name="" alias="true" withSubpackages="true" />
-        </value>
-      </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CONTINUATION_INDENT_FOR_EXPRESSION_BODIES" value="true" />

--- a/syft/src/main/java/org/openmined/syft/networking/clients/SocketClient.kt
+++ b/syft/src/main/java/org/openmined/syft/networking/clients/SocketClient.kt
@@ -174,7 +174,7 @@ internal class SocketClient(
     override fun dispose() {
         compositeDisposable.clear()
         if (isDisposed) {
-            syftWebSocket.close()
+            syftWebSocket.dispose()
             socketClientSubscribed.set(false)
             Log.d(TAG, "Socket Client Disposed")
         } else

--- a/syft/src/test/java/org/openmined/syft/unit/networking/clients/WebSocketClientTest.kt
+++ b/syft/src/test/java/org/openmined/syft/unit/networking/clients/WebSocketClientTest.kt
@@ -1,4 +1,56 @@
 package org.openmined.syft.unit.networking.clients
 
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.serialization.json.json
+import org.junit.Test
+import org.openmined.syft.networking.clients.SyftWebSocket
+import org.openmined.syft.networking.requests.NetworkingProtocol
+
+
+@ExperimentalUnsignedTypes
 internal class WebSocketClientTest {
+
+    private val webSocket = SyftWebSocket(NetworkingProtocol.HTTP, "pygrid.url", 2000u)
+
+    @Test
+    fun `verify calling start function should connect and initialized the web socket`() {
+        val processor = webSocket.start()
+        processor.test().assertEmpty()
+        processor.test().assertNotComplete()
+    }
+
+    @Test
+    fun `verify calling send function should sending message through the socket connection`() {
+        webSocket.start()
+        val message = json {
+            "data" to "data"
+        }
+        assert(webSocket.send(message))
+    }
+
+    @Test
+    fun `verify disposing the socket will close the connection`() {
+        webSocket.start()
+        assert(webSocket.isConnected.get())
+
+        webSocket.dispose()
+        assert(!webSocket.isConnected.get())
+    }
+
+    @Test
+    fun `socket connection should reconnect after failure`() {
+        val listener = mock<SyftWebSocket.SyftSocketListener>()
+        whenever(listener.onFailure(mock(), mock(), mock())).thenAnswer{ throw Exception() }
+
+        webSocket.syftSocketListener = listener
+        assert(!webSocket.isConnected.get())
+
+        webSocket.start()
+        assert(webSocket.isConnected.get())
+
+        listener.onFailure(mock(), mock(), mock())
+        assert(webSocket.isConnected.get())
+    }
+
 }


### PR DESCRIPTION
## Description
Implement exponential backoff to control and prevent Syft to reconnect indefinitely in case of the connection failed. [Issue 221](https://github.com/OpenMined/KotlinSyft/issues/221).

## Affected Dependencies
None

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
