### PR TITLE
updated README example to match current API

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ You can use KotlinSyft as a front-end or as a background service. The following 
             newJob.report(diff)
         }
 
-        fun onRejected() {
+        override fun onRejected(timeout: String) {
         // Implement this function to define what your worker will do when your worker is rejected from the cycle
         }
 

--- a/README.md
+++ b/README.md
@@ -68,10 +68,8 @@ As a developer, there are few steps to building your own secure federated learni
 You can use KotlinSyft as a front-end or as a background service. The following is a quick start example usage:
 
 ```kotlin
-    val userId = "my Id"
-
     // Optional: Make an http request to your server to get an authentication token
-    val authToken = apiClient.requestToken("https://www.mywebsite.com/request-token/$userId")
+    val authToken = "yourAuthToken"
 
     // The config defines all the adjustable properties of the syft worker
     // The url entered here cannot define connection protocol like https/wss since the worker allots them by its own
@@ -79,7 +77,7 @@ You can use KotlinSyft as a front-end or as a background service. The following 
     val config = SyftConfiguration.builder(this, "www.mypygrid-url.com").build()
 
     // Initiate Syft worker to handle all your jobs
-    val syftWorker = Syft.getInstance(authToken, configuration)
+    val syftWorker = Syft.getInstance(config, authToken)
 
     // Create a new Job
     val newJob = syftWorker.newJob("mnist", "1.0.0")
@@ -119,12 +117,14 @@ You can use KotlinSyft as a front-end or as a background service. The following 
                     )
                 )
                 // your custom implementation to read a databatch from your data
-                val batchData = dataRepository.loadDataBatch(clientConfig.batchSize)
+                val batchData = dataRepository.loadDataBatch(
+		    (clientConfig.planArgs["batch_size"] ?: error("batch_size doesn't exist")).toInt()
+		)
                 //get Model weights and return if not set already
-                val modelParams = model.getParamArray() ?: return
+                val modelParams = model.paramArray ?: return
                 val paramIValue = IValue.listFrom(*modelParams)
                 // plan.execute runs a single gradient step and returns the output as PyTorch IValue
-                val output = plan.execute(
+                val output = plan?.execute(
                     batchData.first,
                     batchData.second,
                     batchIValue,
@@ -132,13 +132,13 @@ You can use KotlinSyft as a front-end or as a background service. The following 
                 )?.toTuple()
                 // The output is a tuple with outputs defined by the pysyft plan along with all the model params
                 output?.let { outputResult ->
-                    val paramSize = model.modelState!!.syftTensors.size
+                    val paramSize = model.stateTensorSize!!
                     // The model params are always appended at the end of the output tuple
                     val beginIndex = outputResult.size - paramSize
                     val updatedParams =
                             outputResult.slice(beginIndex until outputResult.size)
                     // update your model. You can perform any arbitrary computation and checkpoint creation with these model weights
-                    model.updateModel(updatedParams.map { it.toTensor() })
+                    model.updateModel(updatedParams)
                     // get the required loss, accuracy, etc values just like you do in Pytorch Android
                     val accuracy = outputResult[0].toTensor().dataAsFloatArray.last()
                 }
@@ -149,7 +149,7 @@ You can use KotlinSyft as a front-end or as a background service. The following 
             mnistJob.report(diff)
         }
 
-        override fun onRejected() {
+        fun onRejected() {
         // Implement this function to define what your worker will do when your worker is rejected from the cycle
         }
 

--- a/README.md
+++ b/README.md
@@ -144,9 +144,9 @@ You can use KotlinSyft as a front-end or as a background service. The following 
                 }
             }
             // Once training finishes generate the model diff
-            val diff = mnistJob.createDiff()
+            val diff = newJob.createDiff()
             // Report the diff to PyGrid and finish the cycle
-            mnistJob.report(diff)
+            newJob.report(diff)
         }
 
         fun onRejected() {


### PR DESCRIPTION
## Description
The goal of this pull request is to update the README example to match more closely the current API for the library.

NOTE: one thing I found is that I need to keep adding dependencies which I think should be resolved by  `org.openmined.kotlinsyft:syft:0.1.3` itself. For example, I needed to add org.pytorch:pytorch_android to by apps dependencies. (https://github.com/StevenMHernandez/TestKotlinSyft/blob/master/app/build.gradle#L33). I also had to add some other dependencies that you would expect pytorch to do automatically. For example:

```
    implementation "io.reactivex.rxjava2:rxjava:2.2.12"
    implementation "com.squareup.okhttp3:okhttp:4.3.1"
    implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.14.0"
    implementation "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:0.4.0"
    implementation "com.squareup.retrofit2:retrofit:2.7.1"
    implementation "com.squareup.retrofit2:adapter-rxjava2:2.7.1"
```

## Affected Dependencies
None

## How has this been tested?
I built a new app in Android Studio and applied the current version of the README. This would not run immediately. Next, I added the following change which cleared up IDE errors and allowed me to build the app successfully. (https://github.com/StevenMHernandez/TestKotlinSyft/commit/b0a87a040f22a86bbecddcc689424943268a7e6c)

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [N/A] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [N/A] My changes are covered by tests
