### PR TITLE
Unique data source per job

### DIFF
--- a/syft/src/main/java/org/openmined/syft/Syft.kt
+++ b/syft/src/main/java/org/openmined/syft/Syft.kt
@@ -170,8 +170,8 @@ class Syft internal constructor(
             is Either.Right -> syftConfig.getSignallingClient().getCycle(
                 CycleRequest(
                     id,
-                    job.jobId.modelName,
-                    job.jobId.version,
+                    job.modelName,
+                    job.version,
                     ping ?: -1,
                     downloadSpeed ?: 0.0f,
                     uploadSpeed ?: 0.0f
@@ -219,8 +219,8 @@ class Syft internal constructor(
             syftConfig.getSignallingClient().authenticate(
                 AuthenticationRequest(
                     authToken,
-                    job.jobId.modelName,
-                    job.jobId.version
+                    job.modelName,
+                    job.version
                 )
             )
                     .compose(syftConfig.networkingSchedulers.applySingleSchedulers())

--- a/syft/src/main/java/org/openmined/syft/datamodels/JobDataModel.kt
+++ b/syft/src/main/java/org/openmined/syft/datamodels/JobDataModel.kt
@@ -1,0 +1,42 @@
+package org.openmined.syft.datamodels
+
+import java.security.MessageDigest
+
+/**
+ * A uniquer identifier class for the job
+ * @property modelName The name of the model used in the job while querying PyGrid
+ * @property version The model version in PyGrid
+ */
+class JobDataModel(
+    val modelName: String,
+    val version: String? = null
+) {
+
+    /**
+     * Unique hash
+     */
+    val id: String get() = hashId()
+
+    /**
+     * Check if two [JobDataModel] are same. Matches both model names and version if [version] is not null for param and current jobId.
+     * @param modelName the modelName of the jobId which has to be compared with the current object
+     * @param version the version of the jobID which ahs to be compared with the current jobId
+     * @return true if JobId match
+     * @return false otherwise
+     */
+    fun matchWithResponse(modelName: String, version: String? = null) =
+            if (version.isNullOrEmpty() || this.version.isNullOrEmpty())
+                this.modelName == modelName
+            else
+                (this.modelName == modelName) && (this.version == version)
+
+
+    private fun hashId(): String {
+        val input = "$modelName:$version"
+        val bytes = MessageDigest
+                .getInstance("MD5")
+                .digest(input.toByteArray())
+
+        return bytes.joinToString("") { "%02x".format(it) }
+    }
+}

--- a/syft/src/main/java/org/openmined/syft/datasource/JobLocalDataSource.kt
+++ b/syft/src/main/java/org/openmined/syft/datasource/JobLocalDataSource.kt
@@ -12,7 +12,7 @@ import java.io.InputStream
 internal const val DIFF_SCRIPT_NAME = "diff_script.pt"
 private const val TAG = "JobLocalDataSource"
 
-internal class JobLocalDataSource(val jobId: JobId) {
+internal class JobLocalDataSource {
 
     @ExperimentalUnsignedTypes
     fun getDiffScript(config: SyftConfiguration) =
@@ -116,12 +116,12 @@ internal class JobLocalDataSource(val jobId: JobId) {
     }
 
     @ExperimentalUnsignedTypes
-    fun getModelsPath(config: SyftConfiguration) = "${config.filesDir}/${jobId.id}/models"
+    fun getModelsPath(config: SyftConfiguration, jobId: String) = "${config.filesDir}/$jobId/models"
 
     @ExperimentalUnsignedTypes
-    fun getPlansPath(config: SyftConfiguration) = "${config.filesDir}/${jobId.id}/plans"
+    fun getPlansPath(config: SyftConfiguration, jobId: String) = "${config.filesDir}/$jobId/plans"
 
     @ExperimentalUnsignedTypes
-    fun getProtocolsPath(config: SyftConfiguration) = "${config.filesDir}/${jobId.id}/protocols"
+    fun getProtocolsPath(config: SyftConfiguration, jobId: String) = "${config.filesDir}/$jobId/protocols"
 
 }

--- a/syft/src/main/java/org/openmined/syft/datasource/JobLocalDataSource.kt
+++ b/syft/src/main/java/org/openmined/syft/datasource/JobLocalDataSource.kt
@@ -3,6 +3,7 @@ package org.openmined.syft.datasource
 import android.util.Log
 import androidx.annotation.VisibleForTesting
 import io.reactivex.Single
+import org.openmined.syft.datamodels.JobDataModel
 import org.openmined.syft.domain.SyftConfiguration
 import org.openmined.syftproto.execution.v1.PlanOuterClass
 import java.io.File
@@ -11,7 +12,7 @@ import java.io.InputStream
 internal const val DIFF_SCRIPT_NAME = "diff_script.pt"
 private const val TAG = "JobLocalDataSource"
 
-internal class JobLocalDataSource {
+internal class JobLocalDataSource(val dataModel: JobDataModel) {
 
     @ExperimentalUnsignedTypes
     fun getDiffScript(config: SyftConfiguration) =
@@ -48,8 +49,7 @@ internal class JobLocalDataSource {
             }
         }
     }
-
-
+    
     /**
      * Persist the given inputStream in the specified destination asynchronously
      *
@@ -114,4 +114,14 @@ internal class JobLocalDataSource {
         }
         return file.absolutePath
     }
+
+    @ExperimentalUnsignedTypes
+    fun getModelsPath(config: SyftConfiguration) = "${config.filesDir}/${dataModel.id}/models"
+
+    @ExperimentalUnsignedTypes
+    fun getPlansPath(config: SyftConfiguration) = "${config.filesDir}/${dataModel.id}/plans"
+
+    @ExperimentalUnsignedTypes
+    fun getProtocolsPath(config: SyftConfiguration) = "${config.filesDir}/${dataModel.id}/protocols"
+
 }

--- a/syft/src/main/java/org/openmined/syft/datasource/JobLocalDataSource.kt
+++ b/syft/src/main/java/org/openmined/syft/datasource/JobLocalDataSource.kt
@@ -3,7 +3,7 @@ package org.openmined.syft.datasource
 import android.util.Log
 import androidx.annotation.VisibleForTesting
 import io.reactivex.Single
-import org.openmined.syft.datamodels.JobDataModel
+import org.openmined.syft.execution.JobId
 import org.openmined.syft.domain.SyftConfiguration
 import org.openmined.syftproto.execution.v1.PlanOuterClass
 import java.io.File
@@ -12,7 +12,7 @@ import java.io.InputStream
 internal const val DIFF_SCRIPT_NAME = "diff_script.pt"
 private const val TAG = "JobLocalDataSource"
 
-internal class JobLocalDataSource(val dataModel: JobDataModel) {
+internal class JobLocalDataSource(val jobId: JobId) {
 
     @ExperimentalUnsignedTypes
     fun getDiffScript(config: SyftConfiguration) =
@@ -116,12 +116,12 @@ internal class JobLocalDataSource(val dataModel: JobDataModel) {
     }
 
     @ExperimentalUnsignedTypes
-    fun getModelsPath(config: SyftConfiguration) = "${config.filesDir}/${dataModel.id}/models"
+    fun getModelsPath(config: SyftConfiguration) = "${config.filesDir}/${jobId.id}/models"
 
     @ExperimentalUnsignedTypes
-    fun getPlansPath(config: SyftConfiguration) = "${config.filesDir}/${dataModel.id}/plans"
+    fun getPlansPath(config: SyftConfiguration) = "${config.filesDir}/${jobId.id}/plans"
 
     @ExperimentalUnsignedTypes
-    fun getProtocolsPath(config: SyftConfiguration) = "${config.filesDir}/${dataModel.id}/protocols"
+    fun getProtocolsPath(config: SyftConfiguration) = "${config.filesDir}/${jobId.id}/protocols"
 
 }

--- a/syft/src/main/java/org/openmined/syft/datasource/JobLocalDataSource.kt
+++ b/syft/src/main/java/org/openmined/syft/datasource/JobLocalDataSource.kt
@@ -12,10 +12,10 @@ import java.io.InputStream
 internal const val DIFF_SCRIPT_NAME = "diff_script.pt"
 private const val TAG = "JobLocalDataSource"
 
-internal class JobLocalDataSource {
+@ExperimentalUnsignedTypes
+internal class JobLocalDataSource(private val config: SyftConfiguration) {
 
-    @ExperimentalUnsignedTypes
-    fun getDiffScript(config: SyftConfiguration) =
+    fun getDiffScript() =
             config.context.assets.open("torchscripts/$DIFF_SCRIPT_NAME")
 
     /**
@@ -116,12 +116,12 @@ internal class JobLocalDataSource {
     }
 
     @ExperimentalUnsignedTypes
-    fun getModelsPath(config: SyftConfiguration, jobId: String) = "${config.filesDir}/$jobId/models"
+    fun getModelsPath(jobId: String) = "${config.filesDir}/$jobId/models"
 
     @ExperimentalUnsignedTypes
-    fun getPlansPath(config: SyftConfiguration, jobId: String) = "${config.filesDir}/$jobId/plans"
+    fun getPlansPath(jobId: String) = "${config.filesDir}/$jobId/plans"
 
     @ExperimentalUnsignedTypes
-    fun getProtocolsPath(config: SyftConfiguration, jobId: String) = "${config.filesDir}/$jobId/protocols"
+    fun getProtocolsPath(jobId: String) = "${config.filesDir}/$jobId/protocols"
 
 }

--- a/syft/src/main/java/org/openmined/syft/domain/JobRepository.kt
+++ b/syft/src/main/java/org/openmined/syft/domain/JobRepository.kt
@@ -31,17 +31,13 @@ internal class JobRepository(
     val status: DownloadStatus
         get() = trainingParamsStatus.get()
 
-    fun getModelsPath() =
-            jobLocalDataSource.getModelsPath(config, jobId.id)
+    fun getModelsPath() = jobLocalDataSource.getModelsPath(jobId.id)
 
-    fun getPlansPath() =
-            jobLocalDataSource.getPlansPath(config, jobId.id)
+    fun getPlansPath() = jobLocalDataSource.getPlansPath(jobId.id)
 
-    fun getProtocolsPath() =
-            jobLocalDataSource.getProtocolsPath(config, jobId.id)
+    fun getProtocolsPath() = jobLocalDataSource.getProtocolsPath(jobId.id)
 
-    fun getDiffScript() =
-            jobLocalDataSource.getDiffScript(config)
+    fun getDiffScript() = jobLocalDataSource.getDiffScript()
 
     fun persistToLocalStorage(
         input: InputStream,
@@ -69,7 +65,6 @@ internal class JobRepository(
             Single.zip(
                 getDownloadables(
                     workerId,
-                    config,
                     requestKey,
                     model,
                     plans,
@@ -102,7 +97,6 @@ internal class JobRepository(
 
     private fun getDownloadables(
         workerId: String,
-        config: SyftConfiguration,
         request: String,
         model: SyftModel,
         plans: ConcurrentHashMap<String, Plan>,
@@ -115,13 +109,13 @@ internal class JobRepository(
                     workerId,
                     config,
                     request,
-                    jobLocalDataSource.getPlansPath(config, jobId.id),
+                    jobLocalDataSource.getPlansPath(jobId.id),
                     plan
                 )
             )
         }
         protocols.forEach { (_, protocol) ->
-            protocol.protocolFileLocation = jobLocalDataSource.getProtocolsPath(config, jobId.id)
+            protocol.protocolFileLocation = jobLocalDataSource.getProtocolsPath(jobId.id)
             downloadList.add(
                 processProtocols(
                     workerId,
@@ -147,7 +141,7 @@ internal class JobRepository(
                 .flatMap { modelInputStream ->
                     jobLocalDataSource.saveAsync(
                         modelInputStream,
-                        jobLocalDataSource.getModelsPath(config, jobId.id),
+                        jobLocalDataSource.getModelsPath(jobId.id),
                         "$modelId.pb"
                     )
                 }.flatMap { modelFile ->

--- a/syft/src/main/java/org/openmined/syft/domain/JobRepository.kt
+++ b/syft/src/main/java/org/openmined/syft/domain/JobRepository.kt
@@ -28,6 +28,11 @@ internal class JobRepository(
     val status: DownloadStatus
         get() = trainingParamsStatus.get()
 
+    fun getLocalDataSource() = jobLocalDataSource
+
+    fun getModelsPath(config: SyftConfiguration) =
+            jobLocalDataSource.getModelsPath(config)
+
     fun getDiffScript(config: SyftConfiguration) =
             jobLocalDataSource.getDiffScript(config)
 
@@ -104,13 +109,13 @@ internal class JobRepository(
                     workerId,
                     config,
                     request,
-                    "${config.filesDir}/plans",
+                    jobLocalDataSource.getPlansPath(config),
                     plan
                 )
             )
         }
         protocols.forEach { (_, protocol) ->
-            protocol.protocolFileLocation = "${config.filesDir}/protocols"
+            protocol.protocolFileLocation = jobLocalDataSource.getProtocolsPath(config)
             downloadList.add(
                 processProtocols(
                     workerId,
@@ -136,7 +141,7 @@ internal class JobRepository(
                 .flatMap { modelInputStream ->
                     jobLocalDataSource.saveAsync(
                         modelInputStream,
-                        "${config.filesDir}/models",
+                        jobLocalDataSource.getModelsPath(config),
                         "$modelId.pb"
                     )
                 }.flatMap { modelFile ->

--- a/syft/src/main/java/org/openmined/syft/execution/JobId.kt
+++ b/syft/src/main/java/org/openmined/syft/execution/JobId.kt
@@ -18,19 +18,6 @@ data class JobId(
     val id: String get() = hashId()
 
     /**
-     * Check if two [JobId] are same. Matches both model names and version if [version] is not null for param and current jobId.
-     * @param modelName the modelName of the jobId which has to be compared with the current object
-     * @param version the version of the jobID which ahs to be compared with the current jobId
-     * @return true if JobId match
-     * @return false otherwise
-     */
-    fun matchWithResponse(modelName: String, version: String? = null) =
-            if (version.isNullOrEmpty() || this.version.isNullOrEmpty())
-                this.modelName == modelName
-            else
-                (this.modelName == modelName) && (this.version == version)
-
-    /**
     * Generate a unique hash ID based job name and version
     * */
     private fun hashId(): String {

--- a/syft/src/main/java/org/openmined/syft/execution/JobId.kt
+++ b/syft/src/main/java/org/openmined/syft/execution/JobId.kt
@@ -1,4 +1,4 @@
-package org.openmined.syft.datamodels
+package org.openmined.syft.execution
 
 import java.security.MessageDigest
 
@@ -7,7 +7,7 @@ import java.security.MessageDigest
  * @property modelName The name of the model used in the job while querying PyGrid
  * @property version The model version in PyGrid
  */
-class JobDataModel(
+data class JobId(
     val modelName: String,
     val version: String? = null
 ) {
@@ -18,7 +18,7 @@ class JobDataModel(
     val id: String get() = hashId()
 
     /**
-     * Check if two [JobDataModel] are same. Matches both model names and version if [version] is not null for param and current jobId.
+     * Check if two [JobId] are same. Matches both model names and version if [version] is not null for param and current jobId.
      * @param modelName the modelName of the jobId which has to be compared with the current object
      * @param version the version of the jobID which ahs to be compared with the current jobId
      * @return true if JobId match
@@ -30,7 +30,9 @@ class JobDataModel(
             else
                 (this.modelName == modelName) && (this.version == version)
 
-
+    /**
+    * Generate a unique hash ID based job name and version
+    * */
     private fun hashId(): String {
         val input = "$modelName:$version"
         val bytes = MessageDigest

--- a/syft/src/main/java/org/openmined/syft/execution/SyftJob.kt
+++ b/syft/src/main/java/org/openmined/syft/execution/SyftJob.kt
@@ -8,6 +8,7 @@ import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.disposables.Disposable
 import io.reactivex.processors.PublishProcessor
 import org.openmined.syft.Syft
+import org.openmined.syft.datamodels.JobDataModel
 import org.openmined.syft.datasource.DIFF_SCRIPT_NAME
 import org.openmined.syft.datasource.JobLocalDataSource
 import org.openmined.syft.datasource.JobRemoteDataSource
@@ -65,7 +66,7 @@ class SyftJob internal constructor(
                 worker,
                 config,
                 JobRepository(
-                    JobLocalDataSource(),
+                    JobLocalDataSource(JobDataModel(modelName, version)),
                     JobRemoteDataSource(config.getDownloader())
                 )
             )
@@ -228,7 +229,7 @@ class SyftJob internal constructor(
             DIFF_SCRIPT_NAME
         )
         val oldState =
-                SyftState.loadSyftState("${config.filesDir}/models/${model.pyGridModelId}.pb")
+                SyftState.loadSyftState("${jobRepository.getModelsPath(config)}/${model.pyGridModelId}.pb")
         return model.createDiff(oldState, modulePath)
     }
 

--- a/syft/src/main/java/org/openmined/syft/execution/SyftJob.kt
+++ b/syft/src/main/java/org/openmined/syft/execution/SyftJob.kt
@@ -66,7 +66,7 @@ class SyftJob internal constructor(
                 config,
                 JobRepository(
                     JobId(modelName, version),
-                    JobLocalDataSource(),
+                    JobLocalDataSource(config),
                     JobRemoteDataSource(config.getDownloader()),
                     config
                 )

--- a/syft/src/test/java/org/openmined/syft/unit/datasource/JobLocalDataSourceTest.kt
+++ b/syft/src/test/java/org/openmined/syft/unit/datasource/JobLocalDataSourceTest.kt
@@ -11,7 +11,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
-import org.openmined.syft.datamodels.JobDataModel
+import org.openmined.syft.execution.JobId
 import org.openmined.syft.datasource.DIFF_SCRIPT_NAME
 import org.openmined.syft.datasource.JobLocalDataSource
 import org.openmined.syft.domain.SyftConfiguration
@@ -25,7 +25,8 @@ class JobLocalDataSourceTest {
     @JvmField
     var tempFolder = TemporaryFolder()
 
-    private val jobDataModel = JobDataModel("test", "1.0")
+    private val jobDataModel =
+            JobId("test", "1.0")
 
     private lateinit var cut: JobLocalDataSource
 

--- a/syft/src/test/java/org/openmined/syft/unit/datasource/JobLocalDataSourceTest.kt
+++ b/syft/src/test/java/org/openmined/syft/unit/datasource/JobLocalDataSourceTest.kt
@@ -5,14 +5,13 @@ import android.content.res.AssetManager
 import com.google.protobuf.ByteString
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.spyk
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import org.openmined.syft.datamodels.JobDataModel
 import org.openmined.syft.datasource.DIFF_SCRIPT_NAME
 import org.openmined.syft.datasource.JobLocalDataSource
 import org.openmined.syft.domain.SyftConfiguration
@@ -26,19 +25,33 @@ class JobLocalDataSourceTest {
     @JvmField
     var tempFolder = TemporaryFolder()
 
+    private val jobDataModel = JobDataModel("test", "1.0")
+
+    private lateinit var cut: JobLocalDataSource
+
+    @ExperimentalUnsignedTypes
+    private val config: SyftConfiguration = mockk()
+
+    @ExperimentalUnsignedTypes
+    @Before
+    fun setUp() {
+        every { config.filesDir } answers { File("/filesDir") }
+        cut = JobLocalDataSource(jobDataModel)
+    }
+
     @ExperimentalUnsignedTypes
     @Test
     fun `Given config getDiffScript returns correct asset stream`() {
         val context = mockk<Context>()
+
         val inputStream = mockk<InputStream>()
         val assets = mockk<AssetManager>(){
             every { open("torchscripts/$DIFF_SCRIPT_NAME") } returns inputStream
         }
-        val config = mockk<SyftConfiguration>()
+
         every { config.context } answers { context }
         every { context.assets } answers { assets }
 
-        val cut = JobLocalDataSource()
         cut.getDiffScript(config)
 
         io.mockk.verify {
@@ -51,7 +64,6 @@ class JobLocalDataSourceTest {
         val parent = tempFolder.newFolder("filesDir","parent")
         val inputStream = "Hello".byteInputStream()
         val file = File(parent,"myModel.pb")
-        val cut = JobLocalDataSource()
         val result = cut.save(inputStream, parent.toString(),file.name, true)
         assert(result.endsWith("myModel.pb"))
         assert(file.readText() == "Hello")
@@ -63,7 +75,6 @@ class JobLocalDataSourceTest {
         val parent = File(filesDir,"parent")
         val inputStream = "Hello".byteInputStream()
         val file = File(parent,"myModel.pb")
-        val cut = JobLocalDataSource()
         val result = cut.save(inputStream, parent.toString(),file.name, true)
         assert(result.endsWith("myModel.pb"))
         assert(file.readText() == "Hello")
@@ -71,7 +82,6 @@ class JobLocalDataSourceTest {
 
     @Test
     fun `Given an input stream when save is invoked then absolute path is returned directly if file exists and overwrite is false`() {
-        val cut = JobLocalDataSource()
         val inputStream = "Hello".byteInputStream()
         val file = tempFolder.newFile("myModel.pb")
         val result = cut.save(inputStream, file, false)
@@ -81,7 +91,6 @@ class JobLocalDataSourceTest {
 
     @Test
     fun `Given an input stream when save is invoked then file is created and absolute path is returned`() {
-        val cut = JobLocalDataSource()
         val inputStream = "Hello".byteInputStream()
         val file = tempFolder.newFile("myModel.pb")
         val result = cut.save(inputStream, file,true)
@@ -91,7 +100,6 @@ class JobLocalDataSourceTest {
 
     @Test
     fun `Given an input stream when saveAsync is invoked then absolute path is returned directly if file exists and overwrite is false`() {
-        val cut = JobLocalDataSource()
         val inputStream = "Hello".byteInputStream()
         val file = tempFolder.newFile("myModel.pb")
         val result = cut.saveAsync(inputStream, file,false).test()
@@ -105,7 +113,6 @@ class JobLocalDataSourceTest {
 
     @Test
     fun `Given an input stream when saveAsync is invoked then file is created and absolute path is returned`() {
-        val cut = JobLocalDataSource()
         val inputStream = "Hello".byteInputStream()
         val file = tempFolder.newFile("myModel.pb")
         val result = cut.saveAsync(inputStream, file,true).test()
@@ -119,7 +126,6 @@ class JobLocalDataSourceTest {
 
     @Test
     fun `Given a Torchscript plan when saveTorchscript is invoked it is saved`() {
-        val cut = JobLocalDataSource()
         val file = tempFolder.newFile("torchScript.pt")
         val byteArray = "Something".toByteArray()
         val torchScriptByteString = mock<ByteString> {
@@ -134,5 +140,23 @@ class JobLocalDataSourceTest {
         assert(result.endsWith("torchScript.pt"))
         assert(file.readBytes().isNotEmpty())
 
+    }
+
+    @ExperimentalUnsignedTypes
+    @Test
+    fun `get models path should return models path for a specific job identified by JobId`() {
+        assert(cut.getModelsPath(config) == "${config.filesDir}/${jobDataModel.id}/models")
+    }
+
+    @ExperimentalUnsignedTypes
+    @Test
+    fun `get plans path should return plans path for a specific job identified by JobId`() {
+        assert(cut.getPlansPath(config) == "${config.filesDir}/${jobDataModel.id}/plans")
+    }
+
+    @ExperimentalUnsignedTypes
+    @Test
+    fun `get protocols path should return protocols path for a specific job identified by JobId`() {
+        assert(cut.getProtocolsPath(config) == "${config.filesDir}/${jobDataModel.id}/protocols")
     }
 }

--- a/syft/src/test/java/org/openmined/syft/unit/datasource/JobLocalDataSourceTest.kt
+++ b/syft/src/test/java/org/openmined/syft/unit/datasource/JobLocalDataSourceTest.kt
@@ -34,7 +34,7 @@ class JobLocalDataSourceTest {
     @Before
     fun setUp() {
         every { config.filesDir } answers { File("/filesDir") }
-        cut = JobLocalDataSource()
+        cut = JobLocalDataSource(config)
     }
 
     @ExperimentalUnsignedTypes
@@ -50,7 +50,7 @@ class JobLocalDataSourceTest {
         every { config.context } answers { context }
         every { context.assets } answers { assets }
 
-        cut.getDiffScript(config)
+        cut.getDiffScript()
 
         io.mockk.verify {
             assets.open("torchscripts/$DIFF_SCRIPT_NAME")
@@ -143,18 +143,18 @@ class JobLocalDataSourceTest {
     @ExperimentalUnsignedTypes
     @Test
     fun `get models path should return models path for a specific job identified by JobId`() {
-        assert(cut.getModelsPath(config, "1") == "${config.filesDir}/1/models")
+        assert(cut.getModelsPath("1") == "${config.filesDir}/1/models")
     }
 
     @ExperimentalUnsignedTypes
     @Test
     fun `get plans path should return plans path for a specific job identified by JobId`() {
-        assert(cut.getPlansPath(config, "1") == "${config.filesDir}/1/plans")
+        assert(cut.getPlansPath("1") == "${config.filesDir}/1/plans")
     }
 
     @ExperimentalUnsignedTypes
     @Test
     fun `get protocols path should return protocols path for a specific job identified by JobId`() {
-        assert(cut.getProtocolsPath(config, "1") == "${config.filesDir}/1/protocols")
+        assert(cut.getProtocolsPath("1") == "${config.filesDir}/1/protocols")
     }
 }

--- a/syft/src/test/java/org/openmined/syft/unit/datasource/JobLocalDataSourceTest.kt
+++ b/syft/src/test/java/org/openmined/syft/unit/datasource/JobLocalDataSourceTest.kt
@@ -25,9 +25,6 @@ class JobLocalDataSourceTest {
     @JvmField
     var tempFolder = TemporaryFolder()
 
-    private val jobDataModel =
-            JobId("test", "1.0")
-
     private lateinit var cut: JobLocalDataSource
 
     @ExperimentalUnsignedTypes
@@ -37,7 +34,7 @@ class JobLocalDataSourceTest {
     @Before
     fun setUp() {
         every { config.filesDir } answers { File("/filesDir") }
-        cut = JobLocalDataSource(jobDataModel)
+        cut = JobLocalDataSource()
     }
 
     @ExperimentalUnsignedTypes
@@ -146,18 +143,18 @@ class JobLocalDataSourceTest {
     @ExperimentalUnsignedTypes
     @Test
     fun `get models path should return models path for a specific job identified by JobId`() {
-        assert(cut.getModelsPath(config) == "${config.filesDir}/${jobDataModel.id}/models")
+        assert(cut.getModelsPath(config, "1") == "${config.filesDir}/1/models")
     }
 
     @ExperimentalUnsignedTypes
     @Test
     fun `get plans path should return plans path for a specific job identified by JobId`() {
-        assert(cut.getPlansPath(config) == "${config.filesDir}/${jobDataModel.id}/plans")
+        assert(cut.getPlansPath(config, "1") == "${config.filesDir}/1/plans")
     }
 
     @ExperimentalUnsignedTypes
     @Test
     fun `get protocols path should return protocols path for a specific job identified by JobId`() {
-        assert(cut.getProtocolsPath(config) == "${config.filesDir}/${jobDataModel.id}/protocols")
+        assert(cut.getProtocolsPath(config, "1") == "${config.filesDir}/1/protocols")
     }
 }

--- a/syft/src/test/java/org/openmined/syft/unit/domain/JobRepositoryTest.kt
+++ b/syft/src/test/java/org/openmined/syft/unit/domain/JobRepositoryTest.kt
@@ -94,9 +94,9 @@ class JobRepositoryTest {
         whenever(config.filesDir) doReturn File("/filesDir")
 
         jobLocalDataSource.stub {
-            on { getPlansPath(config, jobId.id) }.thenReturn(localPlansPath)
-            on { getModelsPath(config, jobId.id) }.thenReturn(localModelsPath)
-            on { getProtocolsPath(config, jobId.id) }.thenReturn(localProtocolsPath)
+            on { getPlansPath(jobId.id) }.thenReturn(localPlansPath)
+            on { getModelsPath(jobId.id) }.thenReturn(localModelsPath)
+            on { getProtocolsPath(jobId.id) }.thenReturn(localProtocolsPath)
         }
 
         cut = JobRepository(
@@ -124,7 +124,7 @@ class JobRepositoryTest {
     @Test
     fun `JobRepository forwards the call to getDiffScript by calling jobLocalDataSource`(){
         cut.getDiffScript()
-        verify(jobLocalDataSource).getDiffScript(config)
+        verify(jobLocalDataSource).getDiffScript()
     }
 
     @Test

--- a/syft/src/test/java/org/openmined/syft/unit/domain/JobRepositoryTest.kt
+++ b/syft/src/test/java/org/openmined/syft/unit/domain/JobRepositoryTest.kt
@@ -81,6 +81,8 @@ class JobRepositoryTest {
     private val localPlansPath = "path/hashid/plans"
     private val localProtocolsPath = "path/hashid/protocols"
 
+    private val jobId = JobId("test", "1.0")
+
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
@@ -92,20 +94,16 @@ class JobRepositoryTest {
         whenever(config.filesDir) doReturn File("/filesDir")
 
         jobLocalDataSource.stub {
-            on { jobId }.thenReturn(
-                JobId(
-                    "test",
-                    "1.0"
-                )
-            )
-            on { getPlansPath(config) }.thenReturn(localPlansPath)
-            on { getModelsPath(config) }.thenReturn(localModelsPath)
-            on { getProtocolsPath(config) }.thenReturn(localProtocolsPath)
+            on { getPlansPath(config, jobId.id) }.thenReturn(localPlansPath)
+            on { getModelsPath(config, jobId.id) }.thenReturn(localModelsPath)
+            on { getProtocolsPath(config, jobId.id) }.thenReturn(localProtocolsPath)
         }
 
         cut = JobRepository(
+            jobId,
             jobLocalDataSource,
-            jobRemoteDataSource
+            jobRemoteDataSource,
+            config
         )
     }
 
@@ -125,7 +123,7 @@ class JobRepositoryTest {
 
     @Test
     fun `JobRepository forwards the call to getDiffScript by calling jobLocalDataSource`(){
-        cut.getDiffScript(config)
+        cut.getDiffScript()
         verify(jobLocalDataSource).getDiffScript(config)
     }
 
@@ -152,7 +150,6 @@ class JobRepositoryTest {
 
         cut.downloadData(
             workerId,
-            config,
             requestKey,
             networkDisposable,
             jobStatusProcessor,
@@ -205,7 +202,6 @@ class JobRepositoryTest {
 
         cut.downloadData(
             workerId,
-            config,
             requestKey,
             networkDisposable,
             jobStatusProcessor,
@@ -277,7 +273,6 @@ class JobRepositoryTest {
 
         cut.downloadData(
             workerId = workerId,
-            config = config,
             requestKey = requestKey,
             networkDisposable = networkDisposable,
             jobStatusProcessor = jobStatusProcessor,
@@ -309,7 +304,6 @@ class JobRepositoryTest {
 
         cut.downloadData(
             workerId,
-            config,
             requestKey,
             networkDisposable,
             jobStatusProcessor,

--- a/syft/src/test/java/org/openmined/syft/unit/domain/JobRepositoryTest.kt
+++ b/syft/src/test/java/org/openmined/syft/unit/domain/JobRepositoryTest.kt
@@ -19,7 +19,7 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
-import org.openmined.syft.datamodels.JobDataModel
+import org.openmined.syft.execution.JobId
 import org.openmined.syft.datasource.DIFF_SCRIPT_NAME
 import org.openmined.syft.datasource.JobLocalDataSource
 import org.openmined.syft.datasource.JobRemoteDataSource
@@ -92,7 +92,12 @@ class JobRepositoryTest {
         whenever(config.filesDir) doReturn File("/filesDir")
 
         jobLocalDataSource.stub {
-            on { dataModel }.thenReturn(JobDataModel("test", "1.0"))
+            on { jobId }.thenReturn(
+                JobId(
+                    "test",
+                    "1.0"
+                )
+            )
             on { getPlansPath(config) }.thenReturn(localPlansPath)
             on { getModelsPath(config) }.thenReturn(localModelsPath)
             on { getProtocolsPath(config) }.thenReturn(localProtocolsPath)

--- a/syft/src/test/java/org/openmined/syft/unit/execution/SyftJobTest.kt
+++ b/syft/src/test/java/org/openmined/syft/unit/execution/SyftJobTest.kt
@@ -27,6 +27,7 @@ import org.mockito.ArgumentCaptor
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.openmined.syft.Syft
+import org.openmined.syft.datasource.JobLocalDataSource
 import org.openmined.syft.domain.DownloadStatus
 import org.openmined.syft.domain.JobRepository
 import org.openmined.syft.domain.SyftConfiguration
@@ -162,6 +163,11 @@ class SyftJobTest {
                 eq(false)
             )
         ).doReturn("test module path")
+
+        val jobLocalDataSource = mock<JobLocalDataSource> {
+            on { dataModel }.thenReturn(mockk())
+        }
+        whenever(jobRepository.getLocalDataSource()).thenReturn(jobLocalDataSource)
 
         val jobTest = SyftJob(modelName, modelVersion, worker, config, jobRepository)
 

--- a/syft/src/test/java/org/openmined/syft/unit/execution/SyftJobTest.kt
+++ b/syft/src/test/java/org/openmined/syft/unit/execution/SyftJobTest.kt
@@ -136,7 +136,6 @@ class SyftJobTest {
 
         verify(jobRepository).downloadData(
             workerId = eq("workerId"),
-            config = any(),
             requestKey = anyOrNull(),
             networkDisposable = any(),
             jobStatusProcessor = any(),
@@ -154,7 +153,7 @@ class SyftJobTest {
         val config = mockk<SyftConfiguration>() {
             every { filesDir } returns File("test")
         }
-        whenever(jobRepository.getDiffScript(config)).doReturn(mockk())
+        whenever(jobRepository.getDiffScript()).doReturn(mockk())
         whenever(
             jobRepository.persistToLocalStorage(
                 any(),
@@ -163,11 +162,6 @@ class SyftJobTest {
                 eq(false)
             )
         ).doReturn("test module path")
-
-        val jobLocalDataSource = mock<JobLocalDataSource> {
-            on { jobId }.thenReturn(mockk())
-        }
-        whenever(jobRepository.getLocalDataSource()).thenReturn(jobLocalDataSource)
 
         val jobTest = SyftJob(modelName, modelVersion, worker, config, jobRepository)
 

--- a/syft/src/test/java/org/openmined/syft/unit/execution/SyftJobTest.kt
+++ b/syft/src/test/java/org/openmined/syft/unit/execution/SyftJobTest.kt
@@ -165,7 +165,7 @@ class SyftJobTest {
         ).doReturn("test module path")
 
         val jobLocalDataSource = mock<JobLocalDataSource> {
-            on { dataModel }.thenReturn(mockk())
+            on { jobId }.thenReturn(mockk())
         }
         whenever(jobRepository.getLocalDataSource()).thenReturn(jobLocalDataSource)
 


### PR DESCRIPTION
## Description
Add jobId to JobRepository to create local assets uniquely for each SyftJob. [Issue 215](https://github.com/OpenMined/KotlinSyft/issues/215).

## Affected Dependencies
None.

## How has this been tested?
- Updated the test cases for JobRepository to include jodId.
## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
