### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,16 +195,16 @@ source venv/bin/activate
 make venv
 ```
 
-- From PyGrid folder, start Jupyter Notebook
+- From PySyft folder, start Jupyter Notebook
 
 ```bash
 jupyter notebook
 ```
 
-- Open a browser and navigate to [localhost:8888](http://localhost:8888/). You should be able to see the PyGrid files.
-- In the Jupyter Notebook, navigate to `examples/model-centric`
-- Run the notebook `01-Create-plan.ipynb`. It should host the model on PyGrid.
-- Optionally, run the notebook `02-ExecutePlan.ipynb`. This will train the model on the python worker of PySyft.
+- Open a browser and navigate to [localhost:8888](http://localhost:8888/). You should be able to see the PySyft files.
+- In the Jupyter Notebook, navigate to `examples/tutorials/model-centric-fl`
+- Run the notebook `Part 01 - Create Plan.ipynb`. It should host the model on PyGrid.
+- Optionally, run the notebook `Part 02 - Execute Plan.ipynb`. This will train the model on the python worker of PySyft.
 - The android app connects to your PC's localhost via router (easier approach)
 - Get the IP address of your computer by running `ip address show | grep "inet " | grep -v 127.0.0.1` if using Linux/Mac. For windows there are different steps. Alternatively, if you want to run the demo app in the emulator, use `10.0.2.2` as the IP address.
 - Use this IP address and the port (default:5000) in your login screen to supply the PyGrid server url, e.g., 10.0.2.2:5000


### PR DESCRIPTION
Fixed demo-app execution instructions in README file

## Description
Hi, the purpose of this PR is to fix instruction of demo-app execution.
In the previous instruction, you first have to checkout to certain commit in PyGrid like below.
```bash
git clone https://github.com/OpenMined/PyGrid
cd PyGrid
git checkout 0e93aa645a63a02f45ae72b4ff3106c6402dbadf
```
Probably it is because your demo-app is compatible with that version of docker-compose.
However, you cannot find examples/model-centric directory in that commit version. (as I issued before. https://github.com/OpenMined/KotlinSyft/issues/288)
So it is confused to follow that instruction.
Therefore, I think it would be better to follow tutorial in PySyft (as discussed in Issue).

Rather, it could be an easy way to add a sentence before `From PyGrid folder, start Jupyter Notebook` such as `Get back to latest commit in PyGrid`.
But I think keeping fixed commit version is safe for the future changes.

## Affected Dependencies

## How has this been tested?
I succeeded to run demo-app by following PySyft notebook too.

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [X] My changes are covered by tests
